### PR TITLE
Update ZegoCallInvitationWaiting.js

### DIFF
--- a/src/call_invitation/pages/ZegoCallInvitationWaiting.js
+++ b/src/call_invitation/pages/ZegoCallInvitationWaiting.js
@@ -194,7 +194,7 @@ export default function ZegoUIKitPrebuiltCallWaitingScreen(props) {
       }
     );
 
-    BackHandler.addEventListener('hardwareBackPress', handleBackButton);
+    //BackHandler.addEventListener('hardwareBackPress', handleBackButton);
     navigation.setOptions({ gestureEnabled: false });
 
     return () => {
@@ -203,7 +203,7 @@ export default function ZegoUIKitPrebuiltCallWaitingScreen(props) {
       ZegoUIKit.getSignalingPlugin().onInvitationCanceled(callbackID);
       ZegoUIKit.getSignalingPlugin().onInvitationAccepted(callbackID);
       CallInviteStateManage.onInviteCompletedWithNobody(callbackID);
-      BackHandler.removeEventListener('hardwareBackPress', handleBackButton);
+     // BackHandler.removeEventListener('hardwareBackPress', handleBackButton);
       navigation.setOptions({ gestureEnabled: true });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This Backhandler is not working in React Native ios and Making error to _reactNative.BackHandler.remove...
![Screenshot 2025-06-18 at 11 16 17 AM](https://github.com/user-attachments/assets/d36d1697-252a-474a-b750-a7b1a6e4f523)
After Commting this its working fine 